### PR TITLE
Optionally loosen strictness for certain fields

### DIFF
--- a/src/sdif/fields.py
+++ b/src/sdif/fields.py
@@ -23,7 +23,10 @@ from sdif.time import Time, TimeT
 @runtime_checkable
 class SdifModel(Protocol):
     # __attrs_attrs__: ClassVar  # pyright can't detect this without the benefit of plugins
-    identifier: ClassVar[str]
+
+    @property
+    def identifier(self) -> str:
+        ...
 
 
 class FieldType(Enum):

--- a/src/sdif/model_meta.py
+++ b/src/sdif/model_meta.py
@@ -7,8 +7,24 @@ from sdif.fields import FieldMetadata, FieldType, SdifModel
 REGISTERED_MODELS: dict[str, type[SdifModel]] = {}
 
 
-def spec(start: int, len: int, type: Optional[FieldType] = None, m2: bool = False):
-    return attr.field(metadata=dict(sdif=FieldMetadata(start=start, len=len, type=type, m2=m2)))
+def spec(
+    start: int,
+    len: int,
+    type: Optional[FieldType] = None,
+    m2: bool = False,
+    override_m1: Optional[bool] = None,
+):
+    return attr.field(
+        metadata=dict(
+            sdif=FieldMetadata(
+                start=start,
+                len=len,
+                type=type,
+                m2=m2,
+                override_m1=override_m1,
+            )
+        )
+    )
 
 
 if TYPE_CHECKING:

--- a/src/sdif/models.py
+++ b/src/sdif/models.py
@@ -449,6 +449,9 @@ class RelayName:
 
     relay_team_name:  one alpha char to concatenate with the team abbreviation in
     record C1 -- creates such names as "Dolphins A"
+
+    prelim_order and swimoff_order are M1 in the spec, but not emitted by
+    Meet Manager (https://github.com/tdsmith/sdif/issues/9).
     """
 
     identifier: ClassVar[str] = "F0"
@@ -461,8 +464,8 @@ class RelayName:
     birthdate: Optional[date] = spec(66, 8, m2=True)
     age_or_class: Optional[str] = spec(74, 2)
     sex: SexCode = spec(76, 1)
-    prelim_order: OrderCode = spec(77, 1)
-    swimoff_order: OrderCode = spec(78, 1)
+    prelim_order: Optional[OrderCode] = spec(77, 1, override_m1=True)
+    swimoff_order: Optional[OrderCode] = spec(78, 1, override_m1=True)
     finals_order: OrderCode = spec(79, 1)
     leg_time: Optional[TimeT] = spec(80, 8)
     course: Optional[CourseStatusCode] = spec(88, 1)

--- a/src/sdif/models.py
+++ b/src/sdif/models.py
@@ -3,8 +3,6 @@ from decimal import Decimal
 from enum import Enum
 from typing import ClassVar, Optional
 
-from typing_extensions import Self
-
 from sdif.fields import FieldType
 from sdif.model_meta import model, spec
 from sdif.time import Time
@@ -110,7 +108,7 @@ class CourseStatusCode(Enum):
 
     short_meters_hytek_nonstandard = "S"
 
-    def normalize(self) -> Self:
+    def normalize(self) -> "CourseStatusCode":
         return {
             self.short_meters_int: self.short_meters,
             self.long_meters_int: self.long_meters,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import sdif.fields as fields
+import sdif.models as models
 import sdif.model_meta as model_meta
 
 
@@ -6,3 +7,9 @@ def test_m1_m2_exclusive():
     for cls in model_meta.REGISTERED_MODELS.values():
         for field in fields.record_fields(cls):
             assert not (field.m1 and field.m2)
+
+
+def test_optional_m1_metadata():
+    (field,) = [f for f in fields.record_fields(models.RelayName) if f.name == "prelim_order"]
+    assert field.m1 == True
+    assert field.optional == True

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -115,3 +115,34 @@ def test_round_trip_hytek_signon():
     (record,) = decode_records([orig])
     serialized = encode_records([record])
     assert orig == serialized
+
+
+def test_round_trip_m1_optional_fields():
+    m = models.RelayName(
+        organization=None,
+        team_code="ABC",
+        relay_team_name=None,
+        swimmer_name="Joe Bloggs",
+        uss_number=None,
+        citizen=None,
+        birthdate=None,
+        age_or_class=None,
+        sex=models.SexCode.male,
+        prelim_order=None,
+        swimoff_order=None,
+        finals_order=models.OrderCode.alternate,
+        leg_time=None,
+        course=None,
+        takeoff_time=None,
+        uss_number_new=None,
+        preferred_first_name=None,
+    )
+    serialized = encode_records([m])
+    (recovered,) = decode_records(serialized)
+    assert m == recovered
+
+    with pytest.raises(ValueError):
+        encode_records([m], strict=True)
+
+    with pytest.raises(ValueError):
+        list(decode_records(serialized, strict=True))

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -57,11 +57,12 @@ def test_round_trip_value(field_type: FieldType, len: int, value: Any, expected:
         len=len,
         m1=False,
         m2=False,
+        optional=True,
         record_type=field_type,
         model_type=type(value),
     )
-    assert encode_value(field_def, value) == expected
-    assert decode_value(field_def, expected) == value
+    assert encode_value(field_def, value, strict=True) == expected
+    assert decode_value(field_def, expected, strict=True) == value
 
 
 @pytest.mark.parametrize(
@@ -83,11 +84,12 @@ def test_round_trip_ish_value(
         len=len,
         m1=False,
         m2=False,
+        optional=True,
         record_type=field_type,
         model_type=type(value),
     )
-    assert encode_value(field_def, value) == expected
-    assert decode_value(field_def, expected) == roundtrip
+    assert encode_value(field_def, value, strict=True) == expected
+    assert decode_value(field_def, expected, strict=True) == roundtrip
 
 
 def test_round_trip_record():


### PR DESCRIPTION
Meet Manager fairly regards certain fields as optional which are listed as M1 in the published spec. We should support serializing and deserializing SDIF files where these values are absent.

Adds a new strict mode that requires we match the spec exactly, which is off by default. Notes on the RelayName model that these fields are Optional even though they're "m1".

Fixes #9.