### PR TITLE
Allow for different model registries.

### DIFF
--- a/src/sdif/model_meta.py
+++ b/src/sdif/model_meta.py
@@ -94,10 +94,15 @@ def model(*args, **kwargs):
     if not args:
         return inner
 
+    try:
+        registry = kwargs.pop('registry')
+    except KeyError:
+        registry = REGISTERED_MODELS
+
     model_cls = attr.define(*args, **kwargs)
     validate_model(model_cls)
-    assert model_cls.identifier not in REGISTERED_MODELS
-    REGISTERED_MODELS[model_cls.identifier] = model_cls
+    assert model_cls.identifier not in registry
+    registry[model_cls.identifier] = model_cls
     return model_cls
 
 

--- a/src/sdif/records.py
+++ b/src/sdif/records.py
@@ -174,9 +174,9 @@ def decode_record(record: str, record_type: type[M], strict: bool) -> M:
     return record_type(**kwargs)
 
 
-def decode_records(records: Iterable[str], strict: bool = False) -> Iterable[SdifModel]:
+def decode_records(records: Iterable[str], strict: bool = False, registry: dict[str, type[SdifModel]] = model_meta.REGISTERED_MODELS) -> Iterable[SdifModel]:
     if isinstance(records, str):
         records = records.split(RECORD_SEP)
     for record in records:
-        cls = model_meta.REGISTERED_MODELS[record[:2]]
+        cls = registry[record[:2]]
         yield decode_record(record, cls, strict)


### PR DESCRIPTION
See #20.

This is a first draft of code to allow for different model "registries": basically groups of models. I need this to parse .hy3 files, which have collisions with model identifiers with .cl2 files (such as "B1", for example).

This still needs docs and tests. It's just a draft at this point.

I'm using this to successfully parse .hy3 files.